### PR TITLE
Fix a NPE crash when onUpdateScrollbar() is called before adapter is initialized

### DIFF
--- a/library/src/main/java/com/jaredrummler/fastscrollrecyclerview/FastScrollRecyclerView.java
+++ b/library/src/main/java/com/jaredrummler/fastscrollrecyclerview/FastScrollRecyclerView.java
@@ -340,6 +340,9 @@ public class FastScrollRecyclerView extends RecyclerView implements RecyclerView
    * <p>Override in each subclass of this base class.</p>
    */
   public void onUpdateScrollbar(int dy) {
+    if (getAdapter() == null) {
+      return;
+    }
     int rowCount = getAdapter().getItemCount();
     if (getLayoutManager() instanceof GridLayoutManager) {
       int spanCount = ((GridLayoutManager) getLayoutManager()).getSpanCount();


### PR DESCRIPTION
The adapter can be null when onUpdateScrollbar() is called.  This simple change checks for that to prevent a NPE crash.